### PR TITLE
Fix UTE struct deserialization offsets

### DIFF
--- a/bindings/c/codex.c
+++ b/bindings/c/codex.c
@@ -217,9 +217,11 @@ static size_t ute_read_field(const struct ute_field *field, const uint8_t *in, s
             return 0;
         uint64_t nfields = 0;
         read += ute_decode_varint(in + read, in_size - read, &nfields);
+        if (nfields != field->num_fields)
+            return 0;
         for (size_t i = 0; i < nfields; ++i)
         {
-            read += ute_read_field(&field->fields[i], in + read, in_size - read, (char *)value + i * sizeof(void *));
+            read += ute_read_field(&field->fields[i], in + read, in_size - read, (char *)value + field->fields[i].offset);
         }
         break;
     }


### PR DESCRIPTION
## Summary
- fix struct field pointer arithmetic in C codex
- validate number of struct fields when reading

## Testing
- `make` in `bindings/c/test` *(fails: undefined reference to yaml functions)*
- `go test ./...` in `bindings/golang/test` *(fails: module download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6844891532f4832b8b8686aae86d8108